### PR TITLE
Rework handling of variables present in one file but not the other

### DIFF
--- a/TODO
+++ b/TODO
@@ -12,11 +12,6 @@ Essential
 
 - Implement get_attributes for netcdf_variable_netcdf4.py
 
-- Handle fields present on file1 but absent from file2
-  - First add a test of this to the fortran cprnc to make sure our handling
-    matches the fortran's handling; test a multi-time variable to see how this
-    is handled when there are multiple time slices
-
 - Check if scalar variables are handled correctly; if not, handle them
   specially, either by:
   - Fixing existing VarDiffs / VarInfo to handle scalar variables

--- a/cprnc_py/netcdf/netcdf_file_fake.py
+++ b/cprnc_py/netcdf/netcdf_file_fake.py
@@ -60,6 +60,21 @@ class NetcdfFileFake(NetcdfFile):
         """
         return self._get_dimsize_from_variables(dimname)
 
+    def get_dimlist(self):
+        """Returns a list of dimensions in the netcdf file.
+
+        Assumes that we can get the list of dimensions from the dimensions
+        associated with each variables.
+        """
+        mydims = set()
+        for var in self._variables:
+            mydims = mydims | set(self._variables[var].get_dimensions())
+        return list(mydims)
+
     def _get_variable(self, varname):
         """Returns a NetcdfVariable-like object for the given variable"""
         return self._variables[varname]
+
+    def has_variable(self, varname):
+        """Returns True if the Netcdf file has the requested variable, otherwise False"""
+        return varname in self._variables

--- a/cprnc_py/netcdf/netcdf_variable_scipy.py
+++ b/cprnc_py/netcdf/netcdf_variable_scipy.py
@@ -48,29 +48,7 @@ class NetcdfVariableScipy(NetcdfVariable):
         """
 
         if len(dim_slices) > 0:
-            # TODO(mfd, 2016-09-19) Find a better way of doing this
-            # Alternatively, match the Fortran version and don't
-            # process variables with different shapes
-            try:
-                vardata = self._var[dim_slices].copy()
-            except IndexError as err:
-                vardata = []
-                for i in dim_slices:
-                    try:
-                        data = self._var[i]
-                    except IndexError:
-                        try:
-                            for j in i:
-                                try:
-                                    vardata.append(self._var[j])
-                                except IndexError:
-                                    pass
-                        except TypeError:
-                            pass
-                    else:
-                        vardata.append(data)
-                return np.array(vardata)
-
+            vardata = self._var[dim_slices].copy()
         else:
             # Scalar data
             vardata = np.array(self._var.getValue())

--- a/cprnc_py/tests/test_netcdf_file_fake.py
+++ b/cprnc_py/tests/test_netcdf_file_fake.py
@@ -1,0 +1,22 @@
+#!/usr/bin/env python
+
+from __future__ import print_function
+
+import unittest
+from cprnc_py.netcdf.netcdf_file_fake import NetcdfFileFake
+from cprnc_py.netcdf.netcdf_variable_fake import NetcdfVariableFake
+import numpy as np
+from cprnc_py.test_utils.custom_assertions import CustomAssertions
+
+class TestNetcdfFileFake(CustomAssertions):
+    def test_get_dimlist(self):
+        var1 = NetcdfVariableFake(np.array([[1,2,3],[4,5,6]]),
+                                  dimnames=['dim1','dim2'])
+        var2 = NetcdfVariableFake(np.array([[1,2,3],[4,5,6]]),
+                                  dimnames=['dim1','dim3'])
+        fl = NetcdfFileFake('myfile', variables = {'var1':var1, 'var2':var2})
+        mydims = sorted(fl.get_dimlist())
+        self.assertEqual(['dim1','dim2','dim3'], mydims)
+
+if __name__ == '__main__':
+    unittest.main()

--- a/cprnc_py/vardiffs.py
+++ b/cprnc_py/vardiffs.py
@@ -270,15 +270,44 @@ class VarDiffsDimSizeDiff(VarDiffsNonAnalyzable):
     def dims_differ(self):
         return True
 
-class VarDiffsUnsharedVar(VarDiffsNonAnalyzable):
+class VarDiffsUnsharedVar(object):
     """This version of VarDiffs is used for variables which aren't shared.
 
     Usage is the same as for the standard VarDiffs.
     """
 
+    def __init__(self, varname, found_in_filenum):
+        """Create a VarDiffsUnsharedVar object
+
+        Args:
+            varname (str): name of variable
+            found_in_filenum (int): file number in which the variable is found;
+                e.g., if it's fuond in file #1 but not in file #2, then
+                found_in_filenum should be 1
+        """
+        self._varname = varname
+        self._found_in_filenum = found_in_filenum
+
     def __str__(self):
-        mystr = "Unshared variable could not be analyzed"
+        if self._found_in_filenum == 1:
+            other_filenum = 2
+        else:
+            other_filenum = 1
+        mystr = "Field found in file {} not found in file {}".format(
+            self._found_in_filenum, other_filenum)
         return mystr
+
+    def vars_differ(self):
+        return False
+
+    def masks_differ(self):
+        return False
+
+    def dims_differ(self):
+        return False
 
     def fields_nonshared(self):
         return True
+
+    def could_not_be_analyzed(self):
+        return False


### PR DESCRIPTION
This includes handling variables with a different number of time slices
(i.e., slices of the separate_dim) on the two files. I now handle this
as non-shared variables, rather than a dif-diff; this feels like the
right thing to do, both in terms of:
- By analogy to the fact that we treat each time slice as a separate
  variable for the sake of analysis
- It seems like this is more likely to do the Right Thing in the case of
  intentional / expected differences in the number of time slices in the
  file

By handling these un-shared variables at a high level, I was able to get
correct results (with no crashes) when comparing the clm h0 & h1 files
(with differing time dimensions), even with the complex try/except block
removed from netcdf_variable_scipy:
_get_data_from_slices. Fundamentally, this is because we now check for
differences in the dimensionality along the separate_dim before trying
to read the variables, rather than reading first and then checking for
dim diffs.

Note that I have removed the check for separate_dim in
file1.get_dimlist() (andsame for file2) in the __init__ method of
FileDiffs. This change is needed for
test_numNonsharedFields_separateDim_varHasDimInOne, and seems the
correct thing to do with our new handling of unshared variables.

I have also changed VarDiffsUnsharedVar to return False fo
could_not_be_analyzed, to be consistent with the Fortran.

This PR also gets the unit tests working again.

In addition to testing via unit tests, I have tested these changes by
carefully examining the output of

cprnc ~/cime/tools/cprnc/test_inputs/clm2.h0.subset.control.nc
~/cime/tools/cprnc/test_inputs/clm2.h1.subset.control.nc

and

cprnc ~/cime/tools/cprnc/test_inputs/clm2.h1.subset.control.nc
~/cime/tools/cprnc/test_inputs/clm2.h0.subset.control.nc